### PR TITLE
Enable multi-step routines

### DIFF
--- a/pages/core.html
+++ b/pages/core.html
@@ -17,10 +17,15 @@
     <div class="card">
       <h2>Build a Routine</h2>
       <form id="coreForm" class="strength-form">
-        <input type="text" placeholder="Exercise Name" required>
-        <input type="number" placeholder="Reps" required>
-        <input type="url" placeholder="Demo Link (URL)" required>
-        <button type="submit">Add to Routine</button>
+        <div class="steps">
+          <div class="step">
+            <input type="text" placeholder="Exercise Name" required>
+            <input type="number" placeholder="Reps" required>
+            <input type="url" placeholder="Demo Link (URL)" required>
+          </div>
+        </div>
+        <button type="button" class="add-step">Add Step</button>
+        <button type="submit">Add Routine</button>
       </form>
       <div id="coreRoutineList"></div>
     </div>

--- a/pages/lower-body.html
+++ b/pages/lower-body.html
@@ -17,10 +17,15 @@
     <div class="card">
       <h2>Build a Routine</h2>
       <form id="lowerBodyForm" class="strength-form">
-        <input type="text" placeholder="Exercise Name" required>
-        <input type="number" placeholder="Reps" required>
-        <input type="url" placeholder="Demo Link (URL)" required>
-        <button type="submit">Add to Routine</button>
+        <div class="steps">
+          <div class="step">
+            <input type="text" placeholder="Exercise Name" required>
+            <input type="number" placeholder="Reps" required>
+            <input type="url" placeholder="Demo Link (URL)" required>
+          </div>
+        </div>
+        <button type="button" class="add-step">Add Step</button>
+        <button type="submit">Add Routine</button>
       </form>
       <div id="lowerBodyRoutineList"></div>
     </div>

--- a/pages/stairs.html
+++ b/pages/stairs.html
@@ -17,10 +17,15 @@
     <div class="card">
       <h2>Build a Routine</h2>
       <form id="stairsForm" class="duration-form">
-        <input type="number" placeholder="Interval Duration (min)" required>
-        <input type="text" placeholder="Pace" required>
-        <input type="number" placeholder="Total Duration (min)" required>
-        <button type="submit">Add to Routine</button>
+        <div class="steps">
+          <div class="step">
+            <input type="number" placeholder="Interval Duration (min)" required>
+            <input type="text" placeholder="Pace" required>
+            <input type="number" placeholder="Total Duration (min)" required>
+          </div>
+        </div>
+        <button type="button" class="add-step">Add Step</button>
+        <button type="submit">Add Routine</button>
       </form>
       <div id="stairsRoutineList"></div>
     </div>

--- a/pages/treadmill.html
+++ b/pages/treadmill.html
@@ -17,10 +17,15 @@
     <div class="card">
       <h2>Build a Routine</h2>
       <form id="treadmillForm" class="duration-form">
-        <input type="number" placeholder="Interval Duration (min)" required>
-        <input type="text" placeholder="Pace" required>
-        <input type="number" placeholder="Total Duration (min)" required>
-        <button type="submit">Add to Routine</button>
+        <div class="steps">
+          <div class="step">
+            <input type="number" placeholder="Interval Duration (min)" required>
+            <input type="text" placeholder="Pace" required>
+            <input type="number" placeholder="Total Duration (min)" required>
+          </div>
+        </div>
+        <button type="button" class="add-step">Add Step</button>
+        <button type="submit">Add Routine</button>
       </form>
       <div id="treadmillRoutineList"></div>
     </div>

--- a/pages/upper-body.html
+++ b/pages/upper-body.html
@@ -17,10 +17,15 @@
     <div class="card">
       <h2>Build a Routine</h2>
       <form id="upperBodyForm" class="strength-form">
-        <input type="text" placeholder="Exercise Name" required>
-        <input type="number" placeholder="Reps" required>
-        <input type="url" placeholder="Demo Link (URL)" required>
-        <button type="submit">Add to Routine</button>
+        <div class="steps">
+          <div class="step">
+            <input type="text" placeholder="Exercise Name" required>
+            <input type="number" placeholder="Reps" required>
+            <input type="url" placeholder="Demo Link (URL)" required>
+          </div>
+        </div>
+        <button type="button" class="add-step">Add Step</button>
+        <button type="submit">Add Routine</button>
       </form>
       <div id="upperBodyRoutineList"></div>
     </div>

--- a/pages/walk.html
+++ b/pages/walk.html
@@ -17,10 +17,15 @@
     <div class="card">
       <h2>Build a Routine</h2>
       <form id="walkForm" class="duration-form">
-        <input type="number" placeholder="Interval Duration (min)" required>
-        <input type="text" placeholder="Pace" required>
-        <input type="number" placeholder="Total Duration (min)" required>
-        <button type="submit">Add to Routine</button>
+        <div class="steps">
+          <div class="step">
+            <input type="number" placeholder="Interval Duration (min)" required>
+            <input type="text" placeholder="Pace" required>
+            <input type="number" placeholder="Total Duration (min)" required>
+          </div>
+        </div>
+        <button type="button" class="add-step">Add Step</button>
+        <button type="submit">Add Routine</button>
       </form>
       <div id="walkRoutineList"></div>
     </div>

--- a/script.js
+++ b/script.js
@@ -1,55 +1,85 @@
+// Enhanced routine builder allowing multiple steps per routine
+
 document.addEventListener('DOMContentLoaded', () => {
-  const durationForm = document.querySelector('.duration-form');
-  const strengthForm = document.querySelector('.strength-form');
-
-  if (durationForm) {
-    const list = document.getElementById(durationForm.id.replace('Form', 'RoutineList'));
-    const storageKey = durationForm.id;
-    loadFromStorage(storageKey, list, 'duration');
-    durationForm.addEventListener('submit', e => {
-      e.preventDefault();
-      const inputs = durationForm.querySelectorAll('input');
-      const routine = {
-        interval: inputs[0].value,
-        pace: inputs[1].value,
-        total: inputs[2].value
-      };
-      appendDurationEntry(list, routine);
-      saveToStorage(storageKey, routine);
-      durationForm.reset();
-    });
-  }
-
-  if (strengthForm) {
-    const list = document.getElementById(strengthForm.id.replace('Form', 'RoutineList'));
-    const storageKey = strengthForm.id;
-    loadFromStorage(storageKey, list, 'strength');
-    strengthForm.addEventListener('submit', e => {
-      e.preventDefault();
-      const inputs = strengthForm.querySelectorAll('input');
-      const routine = {
-        name: inputs[0].value,
-        reps: inputs[1].value,
-        link: inputs[2].value
-      };
-      appendStrengthEntry(list, routine);
-      saveToStorage(storageKey, routine);
-      strengthForm.reset();
-    });
-  }
+  setupRoutineForm('.duration-form', 'duration');
+  setupRoutineForm('.strength-form', 'strength');
 });
 
-function appendDurationEntry(list, { interval, pace, total }) {
+function setupRoutineForm(selector, type) {
+  const form = document.querySelector(selector);
+  if (!form) return;
+
+  const list = document.getElementById(form.id.replace('Form', 'RoutineList'));
+  const storageKey = form.id;
+
+  loadFromStorage(storageKey, list, type);
+
+  const stepsContainer = form.querySelector('.steps');
+  const addStepBtn = form.querySelector('.add-step');
+
+  addStepBtn.addEventListener('click', () => {
+    const step = stepsContainer.firstElementChild.cloneNode(true);
+    step.querySelectorAll('input').forEach(i => i.value = '');
+    stepsContainer.appendChild(step);
+  });
+
+  form.addEventListener('submit', e => {
+    e.preventDefault();
+    const steps = [...stepsContainer.querySelectorAll('.step')].map(step => {
+      const inputs = step.querySelectorAll('input');
+      if (type === 'duration') {
+        return {
+          interval: inputs[0].value,
+          pace: inputs[1].value,
+          total: inputs[2].value
+        };
+      } else {
+        return {
+          name: inputs[0].value,
+          reps: inputs[1].value,
+          link: inputs[2].value
+        };
+      }
+    });
+
+    if (type === 'duration') {
+      appendDurationRoutine(list, steps);
+    } else {
+      appendStrengthRoutine(list, steps);
+    }
+
+    saveToStorage(storageKey, steps);
+
+    while (stepsContainer.children.length > 1) {
+      stepsContainer.removeChild(stepsContainer.lastElementChild);
+    }
+    stepsContainer.querySelectorAll('input').forEach(i => i.value = '');
+  });
+}
+
+function appendDurationRoutine(list, steps) {
   const div = document.createElement('div');
   div.className = 'routine-entry';
-  div.textContent = `Interval: ${interval} min, Pace: ${pace}, Total: ${total} min`;
+  const ol = document.createElement('ol');
+  steps.forEach(s => {
+    const li = document.createElement('li');
+    li.textContent = `Interval: ${s.interval} min, Pace: ${s.pace}, Total: ${s.total} min`;
+    ol.appendChild(li);
+  });
+  div.appendChild(ol);
   list.appendChild(div);
 }
 
-function appendStrengthEntry(list, { name, reps, link }) {
+function appendStrengthRoutine(list, steps) {
   const div = document.createElement('div');
   div.className = 'routine-entry';
-  div.innerHTML = `${name} - ${reps} reps <a href="${link}" target="_blank">demo</a>`;
+  const ol = document.createElement('ol');
+  steps.forEach(s => {
+    const li = document.createElement('li');
+    li.innerHTML = `${s.name} - ${s.reps} reps <a href="${s.link}" target="_blank">demo</a>`;
+    ol.appendChild(li);
+  });
+  div.appendChild(ol);
   list.appendChild(div);
 }
 
@@ -62,6 +92,6 @@ function saveToStorage(key, routine) {
 function loadFromStorage(key, list, type) {
   const arr = JSON.parse(localStorage.getItem(key) || '[]');
   arr.forEach(r => {
-    type === 'duration' ? appendDurationEntry(list, r) : appendStrengthEntry(list, r);
+    type === 'duration' ? appendDurationRoutine(list, r) : appendStrengthRoutine(list, r);
   });
 }


### PR DESCRIPTION
## Summary
- support multiple steps per routine
- add "Add Step" button on all routine forms
- create script to handle adding step fields and saving routines with multiple steps

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68507857d4f083208a9952981161c3b0